### PR TITLE
Refactor as context

### DIFF
--- a/backend/routes/mapRoutes.js
+++ b/backend/routes/mapRoutes.js
@@ -14,7 +14,6 @@ router.get('/all', async (req, res) => {
 
 router.get('/:id', async (req, res) => {
 	const { id } = req.params;
-	console.log(req.body);
 	try {
 		if (id.length !== 12) {
 			return res.status(400).json({ error: 'Invalid map ID length' });

--- a/src/components/event/EventPin.jsx
+++ b/src/components/event/EventPin.jsx
@@ -1,116 +1,114 @@
 import { useState, useContext } from 'react';
 import { EditContext } from '../../pages/editMap/EditContext';
 
-function EventPin({ event, timelineEventPosition, onDragStart }) {
+function EventPin({ event, timelineEventPosition }) {
 	const {
+		updateEvent,
+		draggingEvent,
+		setDraggingEvent,
 		sidebarState,
 
 		toggleSidebar,
 	} = useContext(EditContext);
+	const [timelinePosition, setTimelinePosition] = useState(
+		timelineEventPosition
+	);
 
-	const [dragging, setDragging] = useState(false);
 	const active =
 		JSON.stringify(event.eventId) ===
 		JSON.stringify(sidebarState.event?.eventId);
 
+	const handleDrag = (e) => {
+		e.preventDefault();
+		const timelineRect =
+			e.currentTarget.parentElement.getBoundingClientRect();
+		const newPosition =
+			((e.clientX - timelineRect.left) / timelineRect.width) * 100;
+		//set min position at 0% and max at 100
+		setTimelinePosition(Math.max(0, Math.min(newPosition, 100)));
+	};
+
 	if (!timelineEventPosition) {
 		if (!event.date) {
 			return (
-				<>
-					<div
-						className={`eventPin${active ? ' active' : ''}`}
-						style={{
-							top: `${event.position.top}%`,
-							left: `${event.position.left}%`,
-							translate: `-50% -80%`,
-						}}
-					>
-						<i className="fa-solid fa-location-dot"></i>
-					</div>
-				</>
-			);
-		}
-
-		const handleDragStart = () => {
-			setDragging(true);
-			onDragStart(event.eventId); // Pass eventId
-		};
-
-		const handleDragEnd = () => {
-			setDragging(false);
-		};
-
-		return (
-			<>
 				<div
-					className={`eventPin${active ? ' active' : ''}${
-						dragging ? ' dragging' : ''
-					}`}
+					className={`eventPin${active ? ' active' : ''}`}
 					style={{
 						top: `${event.position.top}%`,
 						left: `${event.position.left}%`,
 						translate: `-50% -80%`,
 					}}
-					draggable
-					onDragStart={handleDragStart}
-					onDragEnd={handleDragEnd}
-					onClick={() =>
-						toggleSidebar({ mode: 'viewEvent', event: event })
-					}
 				>
 					<i className="fa-solid fa-location-dot"></i>
 				</div>
-			</>
+			);
+		}
+
+		const handleDragStart = () => {
+			setDraggingEvent(event.eventId);
+		};
+
+		return (
+			<div
+				id={`event-${event.eventId}`}
+				className={`eventPin${active ? ' active' : ''}`}
+				style={{
+					top: `${event.position.top}%`,
+					left: `${event.position.left}%`,
+					translate: `-50% -80%`,
+				}}
+				draggable
+				onDragStart={handleDragStart}
+				onClick={() =>
+					toggleSidebar({ mode: 'viewEvent', event: event })
+				}
+			>
+				<i className="fa-solid fa-location-dot"></i>
+			</div>
 		);
 	} else {
-		console.log(timelineEventPosition);
 		if (!event.date) {
 			return (
-				<>
-					<div
-						className={`eventPin${active ? ' active' : ''}`}
-						style={{
-							top: `${event.position.top}%`,
-							left: `${timelineEventPosition.left}%`,
-							translate: `-50% -80%`,
-						}}
-					>
-						<i className="fa-solid fa-location-dot"></i>
-					</div>
-				</>
+				<div
+					className={`eventPin${active ? ' active' : ''}${
+						draggingEvent ? dragging : ''
+					}`}
+					style={{
+						top: `50%`,
+						left: `${timelineEventPosition}%`,
+						translate: `0 -50%`,
+					}}
+				>
+					<i className="fa-solid fa-sun"></i>
+				</div>
 			);
 		}
 
-		const handleDragStart = () => {
-			setDragging(true);
-			onDragStart(event.eventId); // Pass eventId
-		};
-
-		const handleDragEnd = () => {
-			setDragging(false);
+		const handleDragStart = (e) => {
+			setDraggingEvent(event.eventId);
+			const img = new Image();
+			img.src = '';
+			e.dataTransfer.setDragImage(img, 0, 0);
 		};
 
 		return (
-			<>
-				<div
-					className={`eventPin${active ? ' active' : ''}${
-						dragging ? ' dragging' : ''
-					}`}
-					style={{
-						top: `${event.position.top}%`,
-						left: `${event.position.left}%`,
-						translate: `-50% -80%`,
-					}}
-					draggable
-					onDragStart={handleDragStart}
-					onDragEnd={handleDragEnd}
-					onClick={() =>
-						toggleSidebar({ mode: 'viewEvent', event: event })
-					}
-				>
-					<i className="fa-solid fa-location-dot"></i>
-				</div>
-			</>
+			<div
+				id={`event-${event.eventId}`}
+				className={`eventPin${active ? ' active' : ''}${
+					draggingEvent ? ' dragging' : ''
+				}`}
+				style={{
+					left: `${timelinePosition}%`,
+				}}
+				draggable
+				onDrag={handleDrag}
+				onDragStart={handleDragStart}
+				onClick={() =>
+					toggleSidebar({ mode: 'viewEvent', event: event })
+				}
+			>
+				<i className="fa-solid fa-sun"></i>
+			</div>
 		);
 	}
 }

--- a/src/components/event/EventPin.jsx
+++ b/src/components/event/EventPin.jsx
@@ -1,56 +1,118 @@
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { EditContext } from '../../pages/editMap/EditContext';
 
-function EventPin({ onSidebarToggle, event, onDragStart, active }) {
+function EventPin({ event, timelineEventPosition, onDragStart }) {
+	const {
+		sidebarState,
+
+		toggleSidebar,
+	} = useContext(EditContext);
+
 	const [dragging, setDragging] = useState(false);
+	const active =
+		JSON.stringify(event.eventId) ===
+		JSON.stringify(sidebarState.event?.eventId);
 
-	if (!event.date) {
+	if (!timelineEventPosition) {
+		if (!event.date) {
+			return (
+				<>
+					<div
+						className={`eventPin${active ? ' active' : ''}`}
+						style={{
+							top: `${event.position.top}%`,
+							left: `${event.position.left}%`,
+							translate: `-50% -80%`,
+						}}
+					>
+						<i className="fa-solid fa-location-dot"></i>
+					</div>
+				</>
+			);
+		}
+
+		const handleDragStart = () => {
+			setDragging(true);
+			onDragStart(event.eventId); // Pass eventId
+		};
+
+		const handleDragEnd = () => {
+			setDragging(false);
+		};
+
 		return (
 			<>
 				<div
-					className={`eventPin${active ? ' active' : ''}`}
+					className={`eventPin${active ? ' active' : ''}${
+						dragging ? ' dragging' : ''
+					}`}
 					style={{
 						top: `${event.position.top}%`,
 						left: `${event.position.left}%`,
 						translate: `-50% -80%`,
 					}}
+					draggable
+					onDragStart={handleDragStart}
+					onDragEnd={handleDragEnd}
+					onClick={() =>
+						toggleSidebar({ mode: 'viewEvent', event: event })
+					}
+				>
+					<i className="fa-solid fa-location-dot"></i>
+				</div>
+			</>
+		);
+	} else {
+		console.log(timelineEventPosition);
+		if (!event.date) {
+			return (
+				<>
+					<div
+						className={`eventPin${active ? ' active' : ''}`}
+						style={{
+							top: `${event.position.top}%`,
+							left: `${timelineEventPosition.left}%`,
+							translate: `-50% -80%`,
+						}}
+					>
+						<i className="fa-solid fa-location-dot"></i>
+					</div>
+				</>
+			);
+		}
+
+		const handleDragStart = () => {
+			setDragging(true);
+			onDragStart(event.eventId); // Pass eventId
+		};
+
+		const handleDragEnd = () => {
+			setDragging(false);
+		};
+
+		return (
+			<>
+				<div
+					className={`eventPin${active ? ' active' : ''}${
+						dragging ? ' dragging' : ''
+					}`}
+					style={{
+						top: `${event.position.top}%`,
+						left: `${event.position.left}%`,
+						translate: `-50% -80%`,
+					}}
+					draggable
+					onDragStart={handleDragStart}
+					onDragEnd={handleDragEnd}
+					onClick={() =>
+						toggleSidebar({ mode: 'viewEvent', event: event })
+					}
 				>
 					<i className="fa-solid fa-location-dot"></i>
 				</div>
 			</>
 		);
 	}
-
-	const handleDragStart = () => {
-		setDragging(true);
-		onDragStart(event.eventId); // Pass eventId
-	};
-
-	const handleDragEnd = () => {
-		setDragging(false);
-	};
-
-	return (
-		<>
-			<div
-				className={`eventPin${active ? ' active' : ''}${
-					dragging ? ' dragging' : ''
-				}`}
-				style={{
-					top: `${event.position.top}%`,
-					left: `${event.position.left}%`,
-					translate: `-50% -80%`,
-				}}
-				draggable
-				onDragStart={handleDragStart}
-				onDragEnd={handleDragEnd}
-				onClick={() =>
-					onSidebarToggle({ mode: 'viewEvent', event: event })
-				}
-			>
-				<i className="fa-solid fa-location-dot"></i>
-			</div>
-		</>
-	);
 }
 
 export default EventPin;

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -87,7 +87,7 @@ function Sidebar() {
 								<CustomDate ref={dateRef} dataType="date" />
 							</label>
 							<button type="submit" className="green">
-								{!event ? 'Create event' : 'Edit event'}
+								{!event ? 'Create event' : 'Save event'}
 							</button>
 						</form>
 					</div>

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -9,6 +9,7 @@ function Sidebar() {
 		map,
 		sidebarState,
 		handleEvent,
+		deleteEvent,
 
 		toggleSidebar,
 	} = useContext(EditContext);
@@ -54,25 +55,6 @@ function Sidebar() {
 			handleEvent(eventData);
 		}
 		toggleSidebar({ mode: mode, event: event })
-	};
-
-	const deleteEvent = async () => {
-		try {
-			const eventResponse = await fetch(
-				`${import.meta.env.VITE_API_URL}/api/event/${event.mapId}/${event.eventId}`,
-				{ method: 'DELETE' }
-			);
-
-			if (!eventResponse.ok) {
-				throw new Error('Failed to delete event');
-			}
-
-			const eventData = await eventResponse.json();
-			console.log('Event deleted successfully', eventData);
-			onDelete();
-		} catch (error) {
-			console.error('Error deleting event:', error);
-		}
 	};
 
 	const renderContent = () => {
@@ -140,7 +122,7 @@ function Sidebar() {
 											`Are you sure you want to delete ${event.title}?`
 										)
 									) {
-										deleteEvent();
+										deleteEvent(event);
 									}
 								}}
 								className="red delete"

--- a/src/components/sidebar/Sidebar.jsx
+++ b/src/components/sidebar/Sidebar.jsx
@@ -1,12 +1,25 @@
-import React, { useEffect, useState, useRef } from 'react';
-import './sidebar.css'; // Change the stylesheet name accordingly
-import CustomDate from '@components/customDate/CustomDate'; // Import the custom date component
+import { useEffect, useState, useRef, useContext } from 'react';
+import './sidebar.css';
+import CustomDate from '@components/customDate/CustomDate';
+import { EditContext } from '../../pages/editMap/EditContext';
 
-function Sidebar({ onSubmit, mode, event, map, onSidebarToggle, onDelete }) {
+function Sidebar() {
+
+	const {
+		map,
+		sidebarState,
+		handleEvent,
+
+		toggleSidebar,
+	} = useContext(EditContext);
+
 	const [title, setTitle] = useState('');
 	const [description, setDescription] = useState('');
 	const [position, setPosition] = useState({ top: null, left: null });
 	const dateRef = useRef(null);
+
+	const mode = sidebarState.mode;
+	const event = sidebarState.event;
 
 	useEffect(() => {
 		if (mode === 'editEvent' && event) {
@@ -35,12 +48,12 @@ function Sidebar({ onSubmit, mode, event, map, onSidebarToggle, onDelete }) {
 
 		if (mode === 'editEvent' && event) {
 			// Pass the event id if editing
-			onSubmit({ ...eventData, eventId: event.eventId });
+			handleEvent({ ...eventData, eventId: event.eventId })
 		} else {
 			// Handle create event if no event object is passed
-			onSubmit(eventData);
+			handleEvent(eventData);
 		}
-		onSidebarToggle({ mode: mode, event: event })
+		toggleSidebar({ mode: mode, event: event })
 	};
 
 	const deleteEvent = async () => {
@@ -112,7 +125,7 @@ function Sidebar({ onSubmit, mode, event, map, onSidebarToggle, onDelete }) {
 							<button
 								className="green edit"
 								onClick={() =>
-									onSidebarToggle({
+									toggleSidebar({
 										mode: 'editEvent',
 										event: event,
 									})
@@ -176,7 +189,7 @@ function Sidebar({ onSubmit, mode, event, map, onSidebarToggle, onDelete }) {
 				<button
 					className="closeButton"
 					onClick={() =>
-						onSidebarToggle({ mode: mode, event: event })
+						toggleSidebar({ mode: mode, event: event })
 					}
 				>
 					X

--- a/src/components/sidebar/sidebar.css
+++ b/src/components/sidebar/sidebar.css
@@ -19,7 +19,6 @@
 
     &:has(+ .timeline.open) {
         height: calc(100% - 200px);
-        box-shadow: 0 0 5px;
     }
 
     .sidebarContent {
@@ -38,6 +37,7 @@
 
     &.open {
         left: 0;
+        box-shadow: 0 0 5px;
     }
 
     .closeButton {

--- a/src/components/timeline/Timeline.jsx
+++ b/src/components/timeline/Timeline.jsx
@@ -1,202 +1,255 @@
+import { useContext } from 'react';
 import './timeline.css';
+import EventPin from '../event/EventPin';
+import { EditContext } from '../../pages/editMap/EditContext';
 
 const convertToTotalDays = (date, equivalences) => {
-    if (!date) return 0;
-    console.log(equivalences);
+	if (!date) return 0;
 
-    const daysInYear = equivalences.month * equivalences.week * equivalences.day; // Total days in one year
-    const daysInMonth = equivalences.week * equivalences.day; // Total days in one month
-    const daysInWeek = equivalences.day; // Total days in one week
+	const daysInYear =
+		equivalences.month * equivalences.week * equivalences.day; // Total days in one year
+	const daysInMonth = equivalences.week * equivalences.day; // Total days in one month
+	const daysInWeek = equivalences.day; // Total days in one week
 
-    // Convert the date to total days using the equivalences
-    const totalDays =
-        date.year * daysInYear + // Days contributed by years
-        date.month * daysInMonth + // Days contributed by months
-        date.week * daysInWeek + // Days contributed by weeks
-        date.day; // Days contributed by days
+	// Convert the date to total days using the equivalences
+	const totalDays =
+		date.year * daysInYear + // Days contributed by years
+		date.month * daysInMonth + // Days contributed by months
+		date.week * daysInWeek + // Days contributed by weeks
+		date.day; // Days contributed by days
 
-    return totalDays;
+	return totalDays;
 };
 
 // Dynamic interval calculation based on equivalences
 const calculateDynamicInterval = (totalDays, equivalences) => {
-    const daysInYear = equivalences.month * equivalences.week * equivalences.day; 
-    const daysInMonth = equivalences.week * equivalences.day; 
-    const daysInWeek = equivalences.day; 
+	const daysInYear =
+		equivalences.month * equivalences.week * equivalences.day;
+	const daysInMonth = equivalences.week * equivalences.day;
+	const daysInWeek = equivalences.day;
 
-    // Calculate potential intervals based on the total timeline
-    const intervals = [];
-    const targetIntervals = 10; // Aim for around 10 intervals
+	// Calculate potential intervals based on the total timeline
+	const intervals = [];
+	const targetIntervals = 10; // Aim for around 10 intervals
 
-    // Calculate intervals in years, months, weeks, and days
-    const yearsInterval = Math.floor(totalDays / daysInYear / targetIntervals);
-    const monthsInterval = Math.floor(totalDays / daysInMonth / targetIntervals);
-    const weeksInterval = Math.floor(totalDays / daysInWeek / targetIntervals);
-    const daysInterval = Math.floor(totalDays / targetIntervals);
+	// Calculate intervals in years, months, weeks, and days
+	const yearsInterval = Math.floor(totalDays / daysInYear / targetIntervals);
+	const monthsInterval = Math.floor(
+		totalDays / daysInMonth / targetIntervals
+	);
+	const weeksInterval = Math.floor(totalDays / daysInWeek / targetIntervals);
+	const daysInterval = Math.floor(totalDays / targetIntervals);
 
-    // Push valid intervals
-    if (yearsInterval > 0) intervals.push(daysInYear * yearsInterval);
-    if (monthsInterval > 0) intervals.push(daysInMonth * monthsInterval);
-    if (weeksInterval > 0) intervals.push(daysInWeek * weeksInterval);
-    if (daysInterval > 0) intervals.push(daysInterval);
+	// Push valid intervals
+	if (yearsInterval > 0) intervals.push(daysInYear * yearsInterval);
+	if (monthsInterval > 0) intervals.push(daysInMonth * monthsInterval);
+	if (weeksInterval > 0) intervals.push(daysInWeek * weeksInterval);
+	if (daysInterval > 0) intervals.push(daysInterval);
 
-    // Return the smallest interval
-    return Math.min(...intervals);
+	// Return the smallest interval
+	return Math.min(...intervals);
 };
 
 // Increment a date object to the next "round" date based on the interval
 const incrementToNextRoundDate = (currentDate, intervalDays, equivalences) => {
-    const daysInYear = equivalences.month * equivalences.week * equivalences.day;
-    const daysInMonth = equivalences.week * equivalences.day;
-    const daysInWeek = equivalences.day;
+	const daysInYear =
+		equivalences.month * equivalences.week * equivalences.day;
+	const daysInMonth = equivalences.week * equivalences.day;
+	const daysInWeek = equivalences.day;
 
-    let newDate = { ...currentDate };
+	let newDate = { ...currentDate };
 
-    // If interval is greater than days in year
-    if (intervalDays >= daysInYear) {
-        newDate.year += Math.floor(intervalDays / daysInYear);
-        intervalDays %= daysInYear; // Remaining days after adding years
-        newDate.month = 0; // Reset months
-        newDate.week = 0; // Reset weeks
-        newDate.day = 0; // Reset days
-    }
+	// If interval is greater than days in year
+	if (intervalDays >= daysInYear) {
+		newDate.year += Math.floor(intervalDays / daysInYear);
+		intervalDays %= daysInYear; // Remaining days after adding years
+		newDate.month = 0; // Reset months
+		newDate.week = 0; // Reset weeks
+		newDate.day = 0; // Reset days
+	}
 
-    // If interval is greater than days in month
-    if (intervalDays >= daysInMonth) {
-        newDate.month += Math.floor(intervalDays / daysInMonth);
-        intervalDays %= daysInMonth; // Remaining days after adding months
-        newDate.week = 0; // Reset weeks
-        newDate.day = 0; // Reset days
-    }
+	// If interval is greater than days in month
+	if (intervalDays >= daysInMonth) {
+		newDate.month += Math.floor(intervalDays / daysInMonth);
+		intervalDays %= daysInMonth; // Remaining days after adding months
+		newDate.week = 0; // Reset weeks
+		newDate.day = 0; // Reset days
+	}
 
-    // If interval is greater than days in week
-    if (intervalDays >= daysInWeek) {
-        newDate.week += Math.floor(intervalDays / daysInWeek);
-        intervalDays %= daysInWeek; // Remaining days after adding weeks
-    }
+	// If interval is greater than days in week
+	if (intervalDays >= daysInWeek) {
+		newDate.week += Math.floor(intervalDays / daysInWeek);
+		intervalDays %= daysInWeek; // Remaining days after adding weeks
+	}
 
-    // Finally add the remaining days
-    newDate.day += intervalDays;
+	// Finally add the remaining days
+	newDate.day += intervalDays;
 
-    // Normalize the date object (handle overflows)
-    if (newDate.day >= daysInWeek) {
-        newDate.week += Math.floor(newDate.day / daysInWeek);
-        newDate.day %= daysInWeek; // Reset days to fit within the week
-    }
-    if (newDate.week >= equivalences.week) {
-        newDate.month += Math.floor(newDate.week / equivalences.week);
-        newDate.week %= equivalences.week; // Reset weeks to fit within the month
-    }
-    if (newDate.month >= equivalences.month) {
-        newDate.year += Math.floor(newDate.month / equivalences.month);
-        newDate.month %= equivalences.month; // Reset months to fit within the year
-    }
+	// Normalize the date object (handle overflows)
+	if (newDate.day >= daysInWeek) {
+		newDate.week += Math.floor(newDate.day / daysInWeek);
+		newDate.day %= daysInWeek; // Reset days to fit within the week
+	}
+	if (newDate.week >= equivalences.week) {
+		newDate.month += Math.floor(newDate.week / equivalences.week);
+		newDate.week %= equivalences.week; // Reset weeks to fit within the month
+	}
+	if (newDate.month >= equivalences.month) {
+		newDate.year += Math.floor(newDate.month / equivalences.month);
+		newDate.month %= equivalences.month; // Reset months to fit within the year
+	}
 
-    return newDate;
+	return newDate;
 };
 
+function Timeline() {
+	const {
+		map,
+		events,
+		settimelineEvents,
+		timelineState,
+		updateEvent,
 
-function Timeline({ timelineState, map, mapEvents }) {
-    if (
-        !map ||
-        !map.dateSystem ||
-        !map.dateSystem.dateStart ||
-        !map.dateSystem.dateEquivalences ||
-        !mapEvents ||
-        mapEvents.length < 2
-    ) {
-        return  <article className={`timeline ${timelineState ? 'open' : ''}`}>
-            <h2>You need at least two events to use the timeline</h2>
-        <div className="bar">
-        </div>
-    </article>
-    }
-    const events = mapEvents.filter((event) => event.date);
+		//other functions
+		toggleSidebar,
+		toggleTimeline,
+	} = useContext(EditContext);
 
-    const equivalences = map.dateSystem.dateEquivalences;
+	if (
+		!map ||
+		!map.dateSystem ||
+		!map.dateSystem.dateStart ||
+		!map.dateSystem.dateEquivalences ||
+		!events ||
+		events.length < 2
+	) {
+		return (
+			<article className={`timeline ${timelineState ? 'open' : ''}`}>
+				<h2>
+					You need at least two timelineEvents to use the timeline
+				</h2>
+				<div className="bar"></div>
+			</article>
+		);
+	}
+	const timelineEvents = events.filter((event) => event.date);
 
-    const getLastDate = () => {
-        const lastEvent = events.reduce((latest, current) => {
-            return current.date.year > latest.date.year ? current : latest;
-        });
-        return lastEvent.date;
-    };
+	const equivalences = map.dateSystem.dateEquivalences;
 
-    const startDate = map.dateSystem.dateStart;
-    const lastDate = getLastDate();
+	const getLastDate = () => {
+		const lastEvent = timelineEvents.reduce((latest, current) => {
+			return current.date.year > latest.date.year ? current : latest;
+		});
+		return lastEvent.date;
+	};
 
-    const totalTimelineDays =
-        convertToTotalDays(lastDate, equivalences) -
-        convertToTotalDays(startDate, equivalences);
+	const startDate = map.dateSystem.dateStart;
+	const lastDate = getLastDate();
 
-    console.log(totalTimelineDays);
+	const totalTimelineDays =
+		convertToTotalDays(lastDate, equivalences) -
+		convertToTotalDays(startDate, equivalences);
 
-    const getDivisionsArray = () => {
-        const divisions = [];
-        const intervalDays = calculateDynamicInterval(totalTimelineDays, equivalences);
+	const getDivisionsArray = () => {
+		const divisions = [];
+		const intervalDays = calculateDynamicInterval(
+			totalTimelineDays,
+			equivalences
+		);
 
-        let currentDate = { ...startDate }; // Make a copy of startDate
+		let currentDate = { ...startDate }; // Make a copy of startDate
 
-        while (convertToTotalDays(currentDate, equivalences) <= convertToTotalDays(lastDate, equivalences)) {
-            divisions.push(currentDate);
-            currentDate = incrementToNextRoundDate(currentDate, intervalDays, equivalences);
-        }
+		while (
+			convertToTotalDays(currentDate, equivalences) <=
+			convertToTotalDays(lastDate, equivalences)
+		) {
+			divisions.push(currentDate);
+			currentDate = incrementToNextRoundDate(
+				currentDate,
+				intervalDays,
+				equivalences
+			);
+		}
 
-        return divisions;
-    };
+		return divisions;
+	};
 
-    const renderEvents = () => {
-        return (
-            <div className="events">
-                {events.map((event, index) => {
-                    const eventDays = convertToTotalDays(event.date, equivalences);
-                    const eventPositionPercent =
-                        ((eventDays - convertToTotalDays(startDate, equivalences)) / totalTimelineDays) * 100;
+	const rendertimelineEvents = () => {
+		return (
+			<div className="timelineEvents">
+				{timelineEvents.map((event, index) => {
+					const eventDays = convertToTotalDays(
+						event.date,
+						equivalences
+					);
+					const eventPositionPercent =
+						((eventDays -
+							convertToTotalDays(startDate, equivalences)) /
+							totalTimelineDays) *
+						100;
 
-                    return (
-                        <div
-                            key={index}
-                            className="event"
-                            style={{ left: `${eventPositionPercent}%` }}
-                        >
-                            <div className="date">
-                                {event.date.year}/{event.date.month}/{event.date.week}/{event.date.day}
-                            </div>
-                        </div>
-                    );
-                })}
-            </div>
-        );
-    };
+					return (
+						<EventPin
+							key={index}
+							event={event}
+							timelineEventPosition={eventPositionPercent}
+							onDragStart={() => handleDragStart(event.eventId)}
+							onDragEnd={handleDragEnd}
+						/>
+					);
+				})}
+			</div>
+		);
+	};
 
-    return (
-        <article className={`timeline ${timelineState ? 'open' : ''}`}>
-            <div className="bar">
-                <div className="years">
-                    <div className="divisions">
-                        {getDivisionsArray().map((division, index) => {
-                            const divisionDays = convertToTotalDays(division, equivalences);
-                            const divisionPositionPercent =
-                                ((divisionDays - convertToTotalDays(startDate, equivalences)) / totalTimelineDays) * 100;
+	const handleDragEnd = (index, newPosition) => {
+		const updatedtimelineEvents = [...timelineEvents];
+		updatedtimelineEvents[index] = {
+			...updatedtimelineEvents[index],
+			position: newPosition,
+		};
+		settimelineEvents(updatedtimelineEvents);
+		updateEvent(updatedtimelineEvents[index]);
+	};
 
-                            return (
-                                <div
-                                    key={index}
-                                    className="division"
-                                    style={{
-                                        left: `${divisionPositionPercent}%`,
-                                    }}
-                                >
-                                    {division.year}/{division.month}/{division.week}/{division.day}
-                                </div>
-                            );
-                        })}
-                    </div>
-                </div>
-            </div>
-            {renderEvents()}
-        </article>
-    );
+	return (
+		<article className={`timeline ${timelineState ? 'open' : ''}`}>
+			<div className="bar">
+				<div className="years">
+					<div className="divisions">
+						{getDivisionsArray().map((division, index) => {
+							const divisionDays = convertToTotalDays(
+								division,
+								equivalences
+							);
+							const divisionPositionPercent =
+								((divisionDays -
+									convertToTotalDays(
+										startDate,
+										equivalences
+									)) /
+									totalTimelineDays) *
+								100;
+
+							return (
+								<div
+									key={index}
+									className="division"
+									style={{
+										left: `${divisionPositionPercent}%`,
+									}}
+								>
+									{division.year}/{division.month}/
+									{division.week}/{division.day}
+								</div>
+							);
+						})}
+					</div>
+				</div>
+			</div>
+			{rendertimelineEvents()}
+		</article>
+	);
 }
 
 export default Timeline;

--- a/src/components/timeline/timeline.css
+++ b/src/components/timeline/timeline.css
@@ -26,8 +26,7 @@
         background: grey;
         border-radius: 2px;
 
-
-        .divisions {
+        .years {
             position: absolute;
             left: 0;
             top: 0;

--- a/src/components/timeline/timeline.css
+++ b/src/components/timeline/timeline.css
@@ -55,35 +55,60 @@
         }
     }
 
+    .timelineDrop {
+        position: absolute;
+        inset: 0;
+    }
+
     .events {
         position: absolute;
         top: 50%;
         left: 50%;
         translate: -50% -50%;
         width: 1000px;
+        height: 10px;
 
-        .event {
+        .eventPin {
             position: absolute;
             top: 50%;
             translate: -50% -50%;
             height: 10px;
             width: 10px;
-            background: red;
+            background: black;
+            color: rgb(220, 82, 12);
+            cursor: pointer;
 
-
-
-            .date {
+            i {
+                filter: drop-shadow(0 0 0.5px black) drop-shadow(0 0 0.5px black) drop-shadow(0 0 0.5px black);
                 position: absolute;
-                bottom: -50px;
+                top: 50%;
                 left: 50%;
-                translate: -50%;
-                opacity: 0;
-                transition: opacity 0.3s;
+                translate: -50% -50%;
+                transition: scale 0.3s;
             }
 
-            &:hover .date {
-                opacity: 1;
+            &.active i {
+                scale: 2;
             }
+        }
+    }
+
+    .closeButton {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background: none;
+        border-radius: unset;
+        font-family: Merienda, sans-serif;
+        color: black;
+        font-size: 30px;
+        padding: 10px;
+        transition: scale 0.3s ease-in-out;
+
+        &:hover, &:focus-within {
+            background: none;
+            scale: 1.2;
+
         }
     }
 }

--- a/src/components/toolbar/Toolbar.jsx
+++ b/src/components/toolbar/Toolbar.jsx
@@ -1,6 +1,15 @@
+import { useContext } from 'react';
 import './toolbar.css';
+import { EditContext } from '../../pages/editMap/EditContext';
 
-const Toolbar = ({ onSidebarToggle, onTimelineToggle }) => {
+const Toolbar = () => {
+	const {
+
+		//other functions
+		toggleSidebar,
+		toggleTimeline,
+	} = useContext(EditContext);
+
 	const handleDragStart = (event) => {
 		// Optional: style adjustments for the drag image, like transparency.
 		// event.currentTarget.style.opacity = '1';
@@ -19,7 +28,7 @@ const Toolbar = ({ onSidebarToggle, onTimelineToggle }) => {
 						title="open map sidebar"
 						className="sidebarButton"
 						onClick={() =>
-							onSidebarToggle({ mode: 'map', event: null })
+							toggleSidebar({ mode: 'map', event: null })
 						}
 					>
 						<i className="fa-solid fa-earth-americas"></i>
@@ -46,7 +55,7 @@ const Toolbar = ({ onSidebarToggle, onTimelineToggle }) => {
 					<button
 						title="open timeline"
 						className="timelineButton"
-						onClick={onTimelineToggle}
+						onClick={toggleTimeline}
 					>
 						<i className="fa-solid fa-timeline"></i>
 					</button>

--- a/src/pages/editMap/EditContext.jsx
+++ b/src/pages/editMap/EditContext.jsx
@@ -33,6 +33,7 @@ export const EditProvider = ({ children }) => {
 	}, []);
 
 	const fetchEvents = async () => {
+		console.log('fetching');
 		try {
 			const eventResponse = await fetch(
 				`${import.meta.env.VITE_API_URL}/api/event/${urlId}`
@@ -47,8 +48,6 @@ export const EditProvider = ({ children }) => {
 	const handleEvent = async (newEvent) => {
 		if (!newEvent.eventId) await saveNewEvent(newEvent);
 		else await updateEvent(newEvent);
-
-		fetchEvents();
 	};
 
 	const saveNewEvent = async (event) => {
@@ -81,14 +80,47 @@ export const EditProvider = ({ children }) => {
 				}
 			);
 			const data = await response.json();
-			//console.log('moving element ', data);
+
+			fetchEvents();
 		} catch (error) {
 			console.error('Error updating event position:', error);
 		}
 	};
 
+	const deleteEvent = async (event) => {
+		try {
+			const eventResponse = await fetch(
+				`${import.meta.env.VITE_API_URL}/api/event/${event.mapId}/${
+					event.eventId
+				}`,
+				{ method: 'DELETE' }
+			);
+
+			if (!eventResponse.ok) {
+				throw new Error('Failed to delete event');
+			}
+
+			const eventData = await eventResponse.json();
+			console.log('Event deleted successfully', eventData);
+			fetchEvents();
+			setSidebar(false);
+		} catch (error) {
+			console.error('Error deleting event:', error);
+		}
+	};
+
+	const handleDragEnd = (index, newPosition) => {
+		const updatedEvents = [...events];
+		updatedEvents[index] = {
+			...updatedEvents[index],
+			position: newPosition,
+		};
+		setEvents(updatedEvents);
+		updateEvent(updatedEvents[index]);
+	};
+
 	const toggleSidebar = (newSidebarState) => {
-        if(sidebarState.mode === 'editEvent') fetchEvents();
+		if (sidebarState.mode === 'editEvent') fetchEvents();
 		if (JSON.stringify(newSidebarState) === JSON.stringify(sidebarState))
 			setSidebar(false);
 		else setSidebar(newSidebarState);
@@ -118,11 +150,14 @@ export const EditProvider = ({ children }) => {
 				draggingEvent,
 				setDraggingEvent,
 
+				handleDragEnd,
+
 				//CRUD functions
 				fetchEvents,
 				handleEvent,
 				saveNewEvent,
 				updateEvent,
+				deleteEvent,
 
 				//other functions
 				//other functions

--- a/src/pages/editMap/EditContext.jsx
+++ b/src/pages/editMap/EditContext.jsx
@@ -1,0 +1,138 @@
+import { createContext, useState, useEffect } from 'react';
+
+export const EditContext = createContext();
+
+export const EditProvider = ({ children }) => {
+	const [map, setMap] = useState(null);
+	const [events, setEvents] = useState([]);
+	const [error, setError] = useState('');
+	const [sidebarState, setSidebar] = useState(false);
+	const [timelineState, setTimeline] = useState(false);
+	const [dropPosition, setDropPosition] = useState(null);
+	const [draggingEvent, setDraggingEvent] = useState(null);
+
+	const urlId = window.location.pathname.match(/\/([^/]+)\/?$/)[1];
+
+	useEffect(() => {
+		const fetchMapData = async () => {
+			if (urlId) {
+				try {
+					const mapResponse = await fetch(
+						`${import.meta.env.VITE_API_URL}/api/map/${urlId}`
+					);
+					const mapData = await mapResponse.json();
+					setMap(mapData);
+				} catch (error) {
+					setError('Error fetching Maps');
+				}
+				fetchEvents();
+			}
+		};
+
+		fetchMapData();
+	}, []);
+
+	const fetchEvents = async () => {
+		try {
+			const eventResponse = await fetch(
+				`${import.meta.env.VITE_API_URL}/api/event/${urlId}`
+			);
+			const eventData = await eventResponse.json();
+			setEvents(eventData);
+		} catch (error) {
+			setError('Error fetching Events');
+		}
+	};
+
+	const handleEvent = async (newEvent) => {
+		if (!newEvent.eventId) await saveNewEvent(newEvent);
+		else await updateEvent(newEvent);
+
+		fetchEvents();
+	};
+
+	const saveNewEvent = async (event) => {
+		try {
+			const response = await fetch(
+				`${import.meta.env.VITE_API_URL}/api/event/${urlId}`,
+				{
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(event),
+				}
+			);
+			const data = await response.json();
+			console.log('Event created:', data);
+		} catch (error) {
+			console.error('Error creating event:', error);
+		}
+	};
+
+	const updateEvent = async (event) => {
+		try {
+			const response = await fetch(
+				`${import.meta.env.VITE_API_URL}/api/event/${urlId}/${
+					event.eventId
+				}`, // Ensure the correct endpoint for updating
+				{
+					method: 'PUT', // Assuming you're using PUT for updating
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify(event),
+				}
+			);
+			const data = await response.json();
+			//console.log('moving element ', data);
+		} catch (error) {
+			console.error('Error updating event position:', error);
+		}
+	};
+
+	const toggleSidebar = (newSidebarState) => {
+        if(sidebarState.mode === 'editEvent') fetchEvents();
+		if (JSON.stringify(newSidebarState) === JSON.stringify(sidebarState))
+			setSidebar(false);
+		else setSidebar(newSidebarState);
+		setDropPosition(null);
+	};
+
+	const toggleTimeline = () => {
+		setTimeline(!timelineState);
+	};
+
+	return (
+		<EditContext.Provider
+			value={{
+				//state
+				map,
+				setMap,
+				events,
+				setEvents,
+				error,
+				setError,
+				sidebarState,
+				setSidebar,
+				timelineState,
+				setTimeline,
+				dropPosition,
+				setDropPosition,
+				draggingEvent,
+				setDraggingEvent,
+
+				//CRUD functions
+				fetchEvents,
+				handleEvent,
+				saveNewEvent,
+				updateEvent,
+
+				//other functions
+				//other functions
+				toggleSidebar,
+				toggleTimeline,
+			}}
+		>
+			{children}
+		</EditContext.Provider>
+	);
+};
+
+export default EditProvider;

--- a/src/pages/editMap/EditMap.jsx
+++ b/src/pages/editMap/EditMap.jsx
@@ -18,6 +18,7 @@ function Edit() {
 		setDropPosition,
 		draggingEvent,
 		setDraggingEvent,
+		handleDragEnd,
 
 		updateEvent,
 
@@ -52,15 +53,7 @@ function Edit() {
 		}
 	};
 
-	const handleDragEnd = (index, newPosition) => {
-		const updatedEvents = [...events];
-		updatedEvents[index] = {
-			...updatedEvents[index],
-			position: newPosition,
-		};
-		setEvents(updatedEvents);
-		updateEvent(updatedEvents[index]);
-	};
+
 
 	const handleImageError = (event) => {
 		event.target.src = defaultMap;
@@ -105,8 +98,6 @@ function Edit() {
 			<EventPin
 				key={index}
 				event={event}
-				onDragStart={() => setDraggingEvent(event.eventId)}
-				onDragEnd={handleDragEnd}
 			/>
 		));
 	};

--- a/src/pages/editMap/EditMap.jsx
+++ b/src/pages/editMap/EditMap.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useContext } from 'react';
 import './editMap.css';
 import Nav from '@components/nav/Nav';
 import Toolbar from '@components/toolbar/Toolbar';
@@ -6,59 +6,28 @@ import EventPin from '@components/event/EventPin';
 import Sidebar from '@components/sidebar/Sidebar';
 import Timeline from '../../components/timeline/Timeline';
 import defaultMap from '@assets/defaultMap.jpg';
+import { EditContext } from './EditContext';
 
 function Edit() {
-	const [map, setMap] = useState(null);
-	const [events, setEvents] = useState([]);
-	const [error, setError] = useState('');
-	const [sidebarState, setSidebar] = useState(false);
-	const [timelineState, setTimeline] = useState(false);
-	const [dropPosition, setDropPosition] = useState(null);
-	const [draggingEvent, setDraggingEvent] = useState(null);
+	const {
+		map,
+		events,
+		setEvents,
+		error,
+		sidebarState,
+		setDropPosition,
+		draggingEvent,
+		setDraggingEvent,
 
-	const urlId = window.location.pathname.match(/\/([^/]+)\/?$/)[1];
+		updateEvent,
 
-	useEffect(() => {
-		const fetchMapData = async () => {
-			if (urlId) {
-				try {
-					const mapResponse = await fetch(
-						`${import.meta.env.VITE_API_URL}/api/map/${urlId}`
-					);
-					const mapData = await mapResponse.json();
-					setMap(mapData);
-				} catch (error) {
-					setError('Error fetching Maps');
-				}
-				fetchEvents();
-			}
-		};
-
-		fetchMapData();
-	}, []);
-
-	const fetchEvents = async () => {
-		try {
-			const eventResponse = await fetch(
-				`${import.meta.env.VITE_API_URL}/api/event/${urlId}`
-			);
-			const eventData = await eventResponse.json();
-			setEvents(eventData);
-		} catch (error) {
-			setError('Error fetching Events');
-		}
-	};
-
-	const handleDragOver = (event) => {
-		event.preventDefault();
-	};
-
-	const handleDragStart = (eventId) => {
-		setDraggingEvent(eventId);
-	};
+		//other functions
+		toggleSidebar,
+	} = useContext(EditContext);
 
 	const handleDrop = (event) => {
 		event.preventDefault();
+
 		const mapRect = event.target.getBoundingClientRect();
 		const newPosition = {
 			top: ((event.clientY - mapRect.top) / mapRect.height) * 100,
@@ -69,12 +38,14 @@ function Edit() {
 			handleDragEnd(index, newPosition);
 			setDraggingEvent(null);
 		} else {
+			if (sidebarState.mode === 'editEvent') {
+			}
 			// Handle creating a new event
 			setDropPosition(newPosition);
 			setEvents((prevEvents) => {
 				return [...prevEvents, { position: newPosition }];
 			});
-			handleSidebarToggle({
+			toggleSidebar({
 				mode: 'editEvent',
 				event: { position: newPosition },
 			});
@@ -91,50 +62,6 @@ function Edit() {
 		updateEvent(updatedEvents[index]);
 	};
 
-	const handleEvent = async (newEvent) => {
-		console.log(newEvent);
-		if (!newEvent.eventId) await saveNewEvent(newEvent);
-		else await updateEvent(newEvent);
-
-		fetchEvents();
-	};
-
-	const saveNewEvent = async (event) => {
-		try {
-			const response = await fetch(
-				`${import.meta.env.VITE_API_URL}/api/event/${urlId}`,
-				{
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(event),
-				}
-			);
-			const data = await response.json();
-			console.log('Event created:', data);
-		} catch (error) {
-			console.error('Error creating event:', error);
-		}
-	};
-
-	const updateEvent = async (event) => {
-		try {
-			const response = await fetch(
-				`${import.meta.env.VITE_API_URL}/api/event/${urlId}/${
-					event.eventId
-				}`, // Ensure the correct endpoint for updating
-				{
-					method: 'PUT', // Assuming you're using PUT for updating
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify(event),
-				}
-			);
-			const data = await response.json();
-			//console.log('moving element ', data);
-		} catch (error) {
-			console.error('Error updating event position:', error);
-		}
-	};
-
 	const handleImageError = (event) => {
 		event.target.src = defaultMap;
 	};
@@ -144,7 +71,9 @@ function Edit() {
 			return (
 				<article
 					className="mapArticle"
-					onDragOver={handleDragOver}
+					onDragOver={(e) => {
+						e.preventDefault();
+					}}
 					onDrop={handleDrop}
 				>
 					<img
@@ -153,7 +82,10 @@ function Edit() {
 						alt="your map"
 						className="map"
 					/>
-					<a className='defaultAttribution' href="https://www.freepik.com/free-vector/ancient-abstract-earth-relief-old-map-generated-conceptual-vector-elevation-map-fantasy-landscape_25145565.htm#query=fantasy%20map&position=0&from_view=keyword&track=ais_hybrid&uuid=1d282c7f-1ee4-42fc-b720-6086b25c7df6">
+					<a
+						className="defaultAttribution"
+						href="https://www.freepik.com/free-vector/ancient-abstract-earth-relief-old-map-generated-conceptual-vector-elevation-map-fantasy-landscape_25145565.htm#query=fantasy%20map&position=0&from_view=keyword&track=ais_hybrid&uuid=1d282c7f-1ee4-42fc-b720-6086b25c7df6"
+					>
 						Default Image by GarryKillian on Freepik
 					</a>
 
@@ -173,28 +105,10 @@ function Edit() {
 			<EventPin
 				key={index}
 				event={event}
-				index={index}
-				onDragStart={() => handleDragStart(event.eventId)}
+				onDragStart={() => setDraggingEvent(event.eventId)}
 				onDragEnd={handleDragEnd}
-				onDelete={fetchEvents}
-				onSidebarToggle={handleSidebarToggle}
-				active={
-					JSON.stringify(event.eventId) ===
-					JSON.stringify(sidebarState.event?.eventId)
-				}
 			/>
 		));
-	};
-
-	const handleSidebarToggle = (newSidebarState) => {
-		if (JSON.stringify(newSidebarState) === JSON.stringify(sidebarState))
-			setSidebar(false);
-		else setSidebar(newSidebarState);
-		setDropPosition(null);
-	};
-
-	const handleTimelineToggle = () => {
-		setTimeline(!timelineState);
 	};
 
 	if (!map) {
@@ -205,25 +119,10 @@ function Edit() {
 		<div className="page edit">
 			<Nav />
 			<main className="content">
-				<Toolbar
-					onSidebarToggle={handleSidebarToggle}
-					onTimelineToggle={handleTimelineToggle}
-				/>
-
+				<Toolbar />
 				{renderMap()}
-				<Sidebar
-					onSubmit={handleEvent}
-					mode={sidebarState.mode}
-					event={sidebarState.event}
-					map={map}
-					onDelete={fetchEvents}
-					onSidebarToggle={handleSidebarToggle}
-				/>
-				<Timeline
-					timelineState={timelineState}
-					map={map}
-					mapEvents={events}
-				/>
+				<Sidebar />
+				<Timeline />
 			</main>
 		</div>
 	);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -1,20 +1,28 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Home from '@pages/home/Home';
-import Create from "@pages/create/Create";
-import All from "@pages/All";
-import Edit from "@pages/editMap/EditMap";
+import Create from '@pages/create/Create';
+import All from '@pages/All';
+import Edit from '@pages/editMap/EditMap';
+import EditProvider from './pages/editMap/EditContext';
 
 const AppRoutes = () => {
-  return (
-    <Router>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/create" element={<Create/>}/>
-        <Route path="/all" element={<All />}/>
-        <Route path="/map/:id" element={<Edit />}/>
-      </Routes>
-    </Router>
-  );
+	return (
+		<Router>
+			<Routes>
+				<Route path="/" element={<Home />} />
+				<Route path="/create" element={<Create />} />
+				<Route path="/all" element={<All />} />
+				<Route
+					path="/map/:id"
+					element={
+						<EditProvider>
+							<Edit />
+						</EditProvider>
+					}
+				/>
+			</Routes>
+		</Router>
+	);
 };
 
 export default AppRoutes;


### PR DESCRIPTION
The editor page had too many components with too many props being passed down and up, this simplifies most of the task. Creating editContext as a context provider and moving there all map and events and UI related state and functions common to all components used.